### PR TITLE
Fix CI permissions error for external PR comments

### DIFF
--- a/.github/workflows/build-mac-app.yml
+++ b/.github/workflows/build-mac-app.yml
@@ -207,7 +207,7 @@ jobs:
         retention-days: 14
 
     - name: Comment on PR
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
## Summary
- Restricts PR commenting to PRs from the same repository (not forks)
- Prevents "Resource not accessible by integration" errors on external contributor PRs

## Problem
When external contributors submit PRs from forks, the CI workflow fails with a permissions error when trying to comment on the PR. This is because GitHub Actions tokens from forked repositories don't have permission to comment on the base repository's PRs.

## Solution
Added a condition to the PR comment step that checks if the PR originates from the same repository:
```yaml
if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```

This ensures:
- ✅ Comments work for PRs from branches in the main repository
- ✅ No permission errors for PRs from forks
- ✅ Build artifacts are still uploaded for all PRs

## Test plan
- [x] CI should pass on this PR (from same repo)
- [ ] External PRs will no longer attempt to comment but will still build successfully

🤖 Generated with [Claude Code](https://claude.ai/code)