### PR TITLE
Update GitHub Actions to use Xcode 16.4

### DIFF
--- a/.github/workflows/build-mac-app.yml
+++ b/.github/workflows/build-mac-app.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Set up Xcode
       run: |
-        sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
         xcodebuild -version
         swift --version
 


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow to use Xcode 16.4 instead of 16.2
- Provides access to the latest Swift toolchain improvements

## Test plan
- [ ] GitHub Actions builds successfully with Xcode 16.4
- [ ] Tests pass
- [ ] App builds and runs correctly

🤖 Generated with [Claude Code](https://claude.ai/code)