### PR TITLE
Filter out negative invoice items from Cursor spending calculations

### DIFF
--- a/VibeMeter/Core/Providers/Cursor/CursorDataTransformer.swift
+++ b/VibeMeter/Core/Providers/Cursor/CursorDataTransformer.swift
@@ -36,13 +36,24 @@ enum CursorDataTransformer {
         logger.info("Transforming invoice response for \(month)/\(year)")
         logger.debug("Invoice response items count: \(response.items?.count ?? 0)")
 
-        let genericItems: [ProviderInvoiceItem] = response.items?.map { item in
-            logger.debug("Processing invoice item: \(item.description) - \(item.cents) cents")
-            return ProviderInvoiceItem(
-                cents: item.cents,
-                description: item.description,
-                provider: .cursor)
-        } ?? []
+        // Filter out negative amounts (e.g. "Mid-month usage paid" credit lines)
+        // so current-month spending reflects actual cost rather than cost minus
+        // payments already captured on a separate invoice
+        let genericItems: [ProviderInvoiceItem] = response.items?
+            .filter { item in
+                if item.cents < 0 {
+                    logger.info("Skipping credit/negative invoice line: \(item.description) - \(item.cents) cents")
+                    return false
+                }
+                return true
+            }
+            .map { item in
+                logger.debug("Processing invoice item: \(item.description) - \(item.cents) cents")
+                return ProviderInvoiceItem(
+                    cents: item.cents,
+                    description: item.description,
+                    provider: .cursor)
+            } ?? []
 
         let genericPricing = response.pricingDescription.map { pricing in
             ProviderPricingDescription(


### PR DESCRIPTION
## Summary
- Filter out negative amounts (credits/refunds) from Cursor invoice calculations
- Ensures accurate spending display by excluding mid-month credits

## Problem
When Cursor issues credits or refunds (e.g., "Mid-month usage paid"), these appear as negative line items in invoices. Including these negative amounts in the total reduces the displayed spending amount, which is incorrect since these credits are already captured on separate invoices.

## Solution
Added filtering logic to skip negative invoice items when calculating monthly spending totals. This ensures users see their actual spending rather than spending minus any credits.

## Test plan
- [ ] Verify positive invoice items are still included
- [ ] Verify negative invoice items are filtered out with appropriate logging
- [ ] Confirm spending totals match expected amounts without credit deductions

This change was extracted from PR #14 as it's the only remaining valuable change not already in main.

🤖 Generated with [Claude Code](https://claude.ai/code)