### PR TITLE
docs: Add link to code signing blog post in scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,6 +30,8 @@ This directory contains all automation scripts for VibeMeter development, buildi
 | [`notarize-app.sh`](./notarize-app.sh) | Notarize signed app bundle | `./scripts/notarize-app.sh <app-path>` |
 | [`create-dmg.sh`](./create-dmg.sh) | Create and sign DMG files | `./scripts/create-dmg.sh <app-path> [dmg-path]` |
 
+📝 **Related article**: [Code Signing and Notarization: Sparkle and Tears](https://steipete.me/posts/2025/code-signing-and-notarization-sparkle-and-tears)
+
 ### 📡 **Update System Scripts**
 
 | Script | Purpose | Usage |


### PR DESCRIPTION
Added reference to "Code Signing and Notarization: Sparkle and Tears" blog post in the Code Signing & Distribution section for additional context.

🤖 Generated with [Claude Code](https://claude.ai/code)