### PR TITLE
Enable silent project regeneration without Xcode restart

### DIFF
--- a/scripts/generate-xcproj.sh
+++ b/scripts/generate-xcproj.sh
@@ -12,10 +12,9 @@
 #   ./scripts/generate-xcproj.sh
 #
 # FEATURES:
-#   - Quits Xcode before generation (to avoid conflicts)
-#   - Runs Tuist project generation
+#   - Runs Tuist project generation silently (no Xcode restart)
 #   - Applies Swift 6 Sendable compliance patches
-#   - Opens the generated workspace in Xcode
+#   - Allows regeneration while Xcode is open
 #
 # DEPENDENCIES:
 #   - Tuist (project generation tool)
@@ -41,10 +40,7 @@ set -e
 # Change to the project directory
 cd "$(dirname "$0")/.."
 
-if [[ "${CI:-}" != "true" ]]; then
-    echo "Quitting Xcode..."
-    osascript -e 'tell application "Xcode" to quit' 2>/dev/null || true
-fi
+# Skip Xcode quit/restart to allow silent regeneration while Xcode is open
 
 echo "Generating Xcode project with Tuist..."
 tuist generate --no-open
@@ -78,9 +74,6 @@ find . -path "*/Derived/InfoPlists+*" -name "*.swift" | while read -r file; do
     patch_info_plist_accessors "$file"
 done
 
-if [[ "${CI:-}" != "true" ]]; then
-    echo "Opening Xcode workspace..."
-    open VibeMeter.xcworkspace
-fi
+# Skip opening workspace to allow silent regeneration
 
 echo "✅ Xcode project generated and patched successfully!"


### PR DESCRIPTION
## Summary
- Remove Xcode quit/restart logic from project generation script
- Allow seamless project regeneration while Xcode remains open

## Changes
- Removed `osascript` call that quits Xcode before generation
- Removed automatic workspace opening after generation
- Updated documentation to reflect silent regeneration capability

## Benefits
- Developers can regenerate the project without interrupting their workflow
- No need to close and reopen Xcode when updating Project.swift or Tuist.swift
- Faster iteration cycles during project configuration changes

## Test plan
- [ ] Run `./scripts/generate-xcproj.sh` while Xcode is open
- [ ] Verify project regenerates without closing Xcode
- [ ] Confirm Xcode picks up the changes (may need to click "Reload" if prompted)
- [ ] Verify Swift 6 patches are still applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)