### PR TITLE
Fix CI test execution by removing invalid -test-iterations parameter

### DIFF
--- a/.github/workflows/build-mac-app.yml
+++ b/.github/workflows/build-mac-app.yml
@@ -97,7 +97,6 @@ jobs:
           -scheme VibeMeter \
           -destination 'platform=macOS,arch=arm64' \
           -configuration Debug \
-          -test-iterations 1 \
           -maximum-parallel-testing-workers 1 \
           | xcbeautify
 


### PR DESCRIPTION
## Summary
- Remove the \ parameter that was causing test failures
- Tests were not running in CI due to this error

## Problem
The CI was failing with:
\\\

This parameter requires a value > 1 or should be omitted entirely for standard test runs.

## Solution
Removed the problematic parameter to allow tests to run normally in CI.

## Test plan
- [ ] CI tests run successfully
- [ ] All 57 test files are executed
- [ ] No xcodebuild errors about test iterations