### PR TITLE
Apply linter formatting changes

### DIFF
--- a/VibeMeter/Core/Models/ClaudeUsageData.swift
+++ b/VibeMeter/Core/Models/ClaudeUsageData.swift
@@ -81,7 +81,14 @@ public struct ClaudeLogEntry: Codable, Identifiable, Sendable {
     }
 
     /// For testing and manual initialization
-    public init(timestamp: Date, model: String?, inputTokens: Int, outputTokens: Int, cacheCreationTokens: Int? = nil, cacheReadTokens: Int? = nil, costUSD: Double? = nil) {
+    public init(
+        timestamp: Date,
+        model: String?,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheCreationTokens: Int? = nil,
+        cacheReadTokens: Int? = nil,
+        costUSD: Double? = nil) {
         self.timestamp = timestamp
         self.model = model
         self.inputTokens = inputTokens
@@ -128,11 +135,11 @@ public struct ClaudeDailyUsage: Identifiable, Sendable {
     public var totalOutputTokens: Int {
         entries.reduce(0) { $0 + $1.outputTokens }
     }
-    
+
     public var totalCacheCreationTokens: Int {
         entries.reduce(0) { $0 + ($1.cacheCreationTokens ?? 0) }
     }
-    
+
     public var totalCacheReadTokens: Int {
         entries.reduce(0) { $0 + ($1.cacheReadTokens ?? 0) }
     }

--- a/VibeMeter/Core/Services/ClaudeCodeLogParser.swift
+++ b/VibeMeter/Core/Services/ClaudeCodeLogParser.swift
@@ -18,9 +18,9 @@ enum ClaudeCodeLogParser {
         }
 
         // Must have message.usage structure with token data
-        guard line.contains("\"message\"") && 
-              line.contains("\"usage\"") && 
-              (line.contains("input_tokens") || line.contains("output_tokens")) else {
+        guard line.contains("\"message\""),
+              line.contains("\"usage\""),
+              line.contains("input_tokens") || line.contains("output_tokens") else {
             return nil
         }
 
@@ -120,7 +120,7 @@ enum ClaudeCodeLogParser {
             let outputTokens = format.message.usage.output_tokens
             let cacheCreationTokens = format.message.usage.cache_creation_input_tokens
             let cacheReadTokens = format.message.usage.cache_read_input_tokens
-            
+
             return ClaudeLogEntry(
                 timestamp: date,
                 model: format.message.model,
@@ -199,7 +199,7 @@ enum ClaudeCodeLogParser {
         if let date = ISO8601DateFormatter.vibeMeterStandard.date(from: timestamp) {
             return date
         }
-        
+
         // Try custom date formatters
         let dateFormatters = [
             { () -> DateFormatter in
@@ -213,13 +213,13 @@ enum ClaudeCodeLogParser {
                 return formatter
             }(),
         ]
-        
+
         for formatter in dateFormatters {
             if let date = formatter.date(from: timestamp) {
                 return date
             }
         }
-        
+
         return nil
     }
 }

--- a/VibeMeter/Core/Services/ClaudeLogManager.swift
+++ b/VibeMeter/Core/Services/ClaudeLogManager.swift
@@ -209,7 +209,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
     private let userDefaults: UserDefaults
     private let authTokenManager = AuthenticationTokenManager()
     private let logProcessor = ClaudeLogProcessor()
-    
+
     // New components
     private let bookmarkManager: ClaudeLogBookmarkManager
     private let fileScanner: ClaudeLogFileScanner
@@ -227,7 +227,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
     private let cacheTimestampKey = "com.vibemeter.claudeLogCacheTimestamp"
     private let fileHashCacheKey = "com.vibemeter.claudeFileHashCache"
     private let cacheVersionKey = "com.vibemeter.claudeLogCacheVersion"
-    
+
     // Cache schema version - increment this when parser format changes
     private let currentCacheVersion = 2 // Incremented for cache token support
 
@@ -289,7 +289,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
         self.bookmarkManager = ClaudeLogBookmarkManager()
         self.fileScanner = ClaudeLogFileScanner()
         self.windowCalculator = ClaudeFiveHourWindowCalculator()
-        
+
         // Check cache version and invalidate if outdated
         let storedVersion = userDefaults.integer(forKey: cacheVersionKey)
         if storedVersion < currentCacheVersion {
@@ -297,7 +297,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
             invalidateCacheInternal()
             userDefaults.set(currentCacheVersion, forKey: cacheVersionKey)
         }
-        
+
         // Set up access state
         self.hasAccess = bookmarkManager.hasAccess
 
@@ -328,7 +328,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
     /// Request access to the Claude logs directory
     public func requestLogAccess() async -> Bool {
         let success = await bookmarkManager.requestLogAccess()
-        
+
         if success {
             hasAccess = true
             
@@ -340,7 +340,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
                 ProviderRegistry.shared.enableProvider(.claude)
             }
         }
-        
+
         return success
     }
 
@@ -348,7 +348,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
     public func revokeAccess() {
         bookmarkManager.revokeAccess()
         hasAccess = false
-        
+
         // Remove the dummy token to indicate Claude is "logged out"
         _ = authTokenManager.deleteToken(for: .claude)
     }
@@ -390,7 +390,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
             delegate?.logProcessingDidFail(error: error)
             return [:]
         }
-        
+
         logger.info("ClaudeLogManager: Looking for Claude logs at: \(claudeURL.path)")
 
         guard fileScanner.claudeLogsExist(at: accessURL) else {
@@ -434,7 +434,7 @@ public final class ClaudeLogManager: ObservableObject, ClaudeLogManagerProtocol,
     public func invalidateCache() {
         invalidateCacheInternal()
     }
-    
+
     private func invalidateCacheInternal() {
         cachedDailyUsage = nil
         cacheTimestamp = nil

--- a/VibeMeter/Presentation/Views/ClaudeUsageReportView.swift
+++ b/VibeMeter/Presentation/Views/ClaudeUsageReportView.swift
@@ -99,7 +99,7 @@ struct ClaudeUsageReportView: View {
                     Spacer()
                 } else {
                     // Show loading indicator at the top if still processing
-                    if dataLoader.isLoading, dataLoader.totalFiles > 0 {
+                    if dataLoader.isLoading && dataLoader.totalFiles > 0 {
                         VStack(spacing: 8) {
                             HStack {
                                 ProgressView()

--- a/VibeMeterTests/ClaudeLogManagerTests.swift
+++ b/VibeMeterTests/ClaudeLogManagerTests.swift
@@ -77,14 +77,14 @@ final class MockClaudeLogManager: ClaudeLogManagerProtocol, @unchecked Sendable 
         getDailyUsageCallCount += 1
         isProcessing = true
         defer { isProcessing = false }
-        
+
         // Simulate progress updates if delegate provided
-        if let delegate = delegate {
+        if let delegate {
             delegate.logProcessingDidStart(totalFiles: 5)
             delegate.logProcessingDidUpdate(filesProcessed: 5, dailyUsage: getDailyUsageResult)
             delegate.logProcessingDidComplete(dailyUsage: getDailyUsageResult)
         }
-        
+
         return getDailyUsageResult
     }
 

--- a/VibeMeterTests/ClaudeLogParsingTests.swift
+++ b/VibeMeterTests/ClaudeLogParsingTests.swift
@@ -217,9 +217,9 @@ struct ClaudeLogParsingTests {
             Issue.record("Failed to parse Claude Code log format")
         }
     }
-    
+
     // MARK: - New tests for enhanced parsing
-    
+
     @Test("Parse Claude Code top-level usage format")
     func parseClaudeCodeTopLevelFormat() {
         let logLine = """
@@ -232,7 +232,7 @@ struct ClaudeLogParsingTests {
         #expect(entry?.outputTokens == 800)
         #expect(entry?.model == "claude-3-5-sonnet")
     }
-    
+
     @Test("Parse Claude Code format with message.usage")
     func parseClaudeCodeMessageUsageFormat() {
         let logLine = """
@@ -244,7 +244,7 @@ struct ClaudeLogParsingTests {
         #expect(entry?.inputTokens == 2000)
         #expect(entry?.outputTokens == 1200)
     }
-    
+
     @Test("Parse Claude Code format with mixed case tokens")
     func parseClaudeCodeMixedCaseTokens() {
         let logLine = """
@@ -256,7 +256,7 @@ struct ClaudeLogParsingTests {
         #expect(entry?.inputTokens == 3000)
         #expect(entry?.outputTokens == 1500)
     }
-    
+
     @Test("Parse Claude Code format with regex fallback")
     func parseClaudeCodeRegexFallback() {
         // Malformed JSON that still contains token data
@@ -269,7 +269,7 @@ struct ClaudeLogParsingTests {
         #expect(entry?.inputTokens == 4000)
         #expect(entry?.outputTokens == 2000)
     }
-    
+
     @Test("Skip non-relevant log lines")
     func skipNonRelevantLines() {
         let nonRelevantLines = [
@@ -285,7 +285,7 @@ struct ClaudeLogParsingTests {
             #expect(entry == nil)
         }
     }
-    
+
     @Test("Parse actual Claude Opus 4 log format from VibeMeter session")
     func parseActualClaudeOpus4LogFormat() {
         // This is the actual format from Claude logs in ~/.claude/projects
@@ -300,7 +300,7 @@ struct ClaudeLogParsingTests {
         #expect(entry?.inputTokens == 1)
         #expect(entry?.outputTokens == 1)
     }
-    
+
     @Test("Parse Claude Code log entry with cache tokens")
     func parseClaudeCodeEntryWithCacheTokens() {
         // Test with cache tokens which VibeMeter currently doesn't track

--- a/VibeMeterTests/TestUtilities/ClaudeLogManagerMock.swift
+++ b/VibeMeterTests/TestUtilities/ClaudeLogManagerMock.swift
@@ -46,19 +46,19 @@ final class ClaudeLogManagerMock: BaseMock, ClaudeLogManagerProtocol {
         defer { isProcessing = false }
         return getDailyUsageResult
     }
-    
+
     func getDailyUsageWithProgress(delegate: ClaudeLogProgressDelegate?) async -> [Date: [ClaudeLogEntry]] {
         recordCall("getDailyUsageWithProgress")
         isProcessing = true
         defer { isProcessing = false }
-        
+
         // Simulate progress updates if delegate provided
-        if let delegate = delegate {
+        if let delegate {
             delegate.logProcessingDidStart(totalFiles: 5)
             delegate.logProcessingDidUpdate(filesProcessed: 5, dailyUsage: getDailyUsageResult)
             delegate.logProcessingDidComplete(dailyUsage: getDailyUsageResult)
         }
-        
+
         return getDailyUsageResult
     }
 


### PR DESCRIPTION
## Summary
- Extracts linter-only changes from the observable-tracking PR to reduce noise
- These are purely formatting changes with no functional impact

## Changes
- Format multi-line init parameters with proper indentation
- Replace double blank lines with single blank lines  
- Convert comma-separated conditions to && operators
- Use shorthand `if let` syntax where applicable
- Remove trailing spaces on empty lines

## Files affected
- `VibeMeter/Core/Models/ClaudeUsageData.swift`
- `VibeMeter/Core/Services/ClaudeCodeLogParser.swift`
- `VibeMeter/Core/Services/ClaudeLogManager.swift`
- `VibeMeter/Presentation/Views/ClaudeUsageReportView.swift`
- `VibeMeterTests/ClaudeLogManagerTests.swift`
- `VibeMeterTests/ClaudeLogParsingTests.swift`
- `VibeMeterTests/TestUtilities/ClaudeLogManagerMock.swift`

## Related PRs
- #34 - Main observable tracking implementation

🤖 Generated with [Claude Code](https://claude.ai/code)