### PR TITLE
fix: expand currency support to include Turkish Lira and other Frankfurter API currencies

### DIFF
--- a/VibeMeter/Core/Services/CurrencyManager.swift
+++ b/VibeMeter/Core/Services/CurrencyManager.swift
@@ -63,6 +63,8 @@ final class CurrencyManager: Sendable {
                 return firstIndex < secondIndex
             }
             return first.key < second.key
+        }.filter { currency in
+            ExchangeRateManager.shared.supportedCurrencies.contains(currency.0)
         }
     }
 

--- a/VibeMeter/Core/Services/ExchangeRateManager.swift
+++ b/VibeMeter/Core/Services/ExchangeRateManager.swift
@@ -28,8 +28,13 @@ public actor ExchangeRateManager: ExchangeRateManagerProtocol {
     private let apiURL = URL(string: "https://api.frankfurter.app/latest")!
     private let baseCurrency = "USD"
 
-    // Supported currencies
-    public nonisolated let supportedCurrencies = ["USD", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK", "NZD"]
+    // Supported currencies - from https://api.frankfurter.app/currencies
+    // This list includes all currencies supported by the Frankfurter API
+    public nonisolated let supportedCurrencies = [
+        "AUD", "BGN", "BRL", "CAD", "CHF", "CNY", "CZK", "DKK", "EUR", "GBP", 
+        "HKD", "HUF", "IDR", "ILS", "INR", "ISK", "JPY", "KRW", "MXN", "MYR", 
+        "NOK", "NZD", "PHP", "PLN", "RON", "SEK", "SGD", "THB", "TRY", "USD", "ZAR"
+    ]
 
     // MARK: - Singleton
 


### PR DESCRIPTION
## Summary
- Fixes issue where Turkish Lira (TRY) and other currencies were selectable in settings but couldn't fetch exchange rates
- Expands supported currencies from 10 to 31 (all currencies supported by Frankfurter API)
- Ensures currency picker only shows currencies with working exchange rate support

## Changes
1. Updated `ExchangeRateManager.supportedCurrencies` to include all 31 currencies from Frankfurter API endpoint (`https://api.frankfurter.app/currencies`)
2. Added filter in `CurrencyManager.availableCurrencies` to only show currencies that have exchange rate support
3. Added API endpoint reference in comment for future maintenance

This ensures all currencies shown in the picker have working exchange rate functionality.