### PR TITLE
Add spending limits toggle for unlimited subscription plans

### DIFF
--- a/VibeMeter/Core/Services/CurrencyOrchestrator.swift
+++ b/VibeMeter/Core/Services/CurrencyOrchestrator.swift
@@ -112,12 +112,14 @@ public final class CurrencyOrchestrator {
             rates: rates,
             targetCurrency: targetCurrency)
 
-        spendingData.updateLimits(
-            for: provider,
-            warningUSD: settingsManager.warningLimitUSD,
-            upperUSD: settingsManager.upperLimitUSD,
-            rates: rates,
-            targetCurrency: targetCurrency)
+        if settingsManager.limitsEnabled {
+            spendingData.updateLimits(
+                for: provider,
+                warningUSD: settingsManager.warningLimitUSD,
+                upperUSD: settingsManager.upperLimitUSD,
+                rates: rates,
+                targetCurrency: targetCurrency)
+        }
     }
 
     /// Checks spending limits and sends notifications for all providers
@@ -142,7 +144,8 @@ public final class CurrencyOrchestrator {
         spendingData: MultiProviderSpendingData,
         targetCurrency: String? = nil,
         exchangeRates: [String: Double]? = nil) async {
-        guard let providerData = spendingData.getSpendingData(for: provider),
+        guard settingsManager.limitsEnabled,
+              let providerData = spendingData.getSpendingData(for: provider),
               let spendingUSD = providerData.currentSpendingUSD else {
             return
         }

--- a/VibeMeter/Core/Services/Settings/SpendingLimitsManager.swift
+++ b/VibeMeter/Core/Services/Settings/SpendingLimitsManager.swift
@@ -18,9 +18,18 @@ public final class SpendingLimitsManager {
     private enum Keys {
         static let warningLimitUSD = "warningLimitUSD"
         static let upperLimitUSD = "upperLimitUSD"
+        static let limitsEnabled = "limitsEnabled"
     }
 
     // MARK: - Spending Limits (stored in USD)
+
+    /// Whether spending limits are enabled
+    public var limitsEnabled: Bool {
+        didSet {
+            userDefaults.set(limitsEnabled, forKey: Keys.limitsEnabled)
+            logger.debug("Limits enabled updated: \(self.limitsEnabled)")
+        }
+    }
 
     /// Warning threshold for spending notifications
     public var warningLimitUSD: Double {
@@ -44,12 +53,13 @@ public final class SpendingLimitsManager {
         self.userDefaults = userDefaults
 
         // Load spending limits with defaults
+        limitsEnabled = userDefaults.object(forKey: Keys.limitsEnabled) as? Bool ?? true
         warningLimitUSD = userDefaults.object(forKey: Keys.warningLimitUSD) as? Double ?? 200.0
         upperLimitUSD = userDefaults.object(forKey: Keys.upperLimitUSD) as? Double ?? 1000.0
 
         logger
             .info(
-                "SpendingLimitsManager initialized - warning: $\(self.warningLimitUSD), upper: $\(self.upperLimitUSD)")
+                "SpendingLimitsManager initialized - enabled: \(self.limitsEnabled), warning: $\(self.warningLimitUSD), upper: $\(self.upperLimitUSD)")
     }
 
     // MARK: - Public Methods
@@ -120,6 +130,7 @@ public final class SpendingLimitsManager {
     /// Resets limits to default values
     public func resetToDefaults() {
         logger.info("Resetting spending limits to defaults")
+        limitsEnabled = true
         warningLimitUSD = 200.0
         upperLimitUSD = 1000.0
     }

--- a/VibeMeter/Core/Services/SettingsManager.swift
+++ b/VibeMeter/Core/Services/SettingsManager.swift
@@ -15,6 +15,7 @@ public protocol SettingsManagerProtocol: AnyObject, Sendable {
     var refreshIntervalMinutes: Int { get set }
 
     // Spending limits (stored in USD)
+    var limitsEnabled: Bool { get set }
     var warningLimitUSD: Double { get set }
     var upperLimitUSD: Double { get set }
 
@@ -102,6 +103,11 @@ public final class SettingsManager: SettingsManagerProtocol {
     }
 
     // Spending limits
+    public var limitsEnabled: Bool {
+        get { limitsManager.limitsEnabled }
+        set { limitsManager.limitsEnabled = newValue }
+    }
+
     public var warningLimitUSD: Double {
         get { limitsManager.warningLimitUSD }
         set { limitsManager.warningLimitUSD = newValue }

--- a/VibeMeter/Presentation/Components/CostTableView.swift
+++ b/VibeMeter/Presentation/Components/CostTableView.swift
@@ -36,8 +36,10 @@ struct CostTableView: View {
             // Total spending in the middle
             totalSpendingSection
 
-            // Spending limits at the bottom
-            spendingLimitsSection
+            // Spending limits at the bottom (only if enabled)
+            if settingsManager?.limitsEnabled ?? true {
+                spendingLimitsSection
+            }
         }
         .id("cost-table-\(spendingData.providersWithData.count)-\(currencyData.selectedCode)-\(totalSpendingHash)")
     }

--- a/VibeMeter/Presentation/Components/StatusBarAccessibilityProvider.swift
+++ b/VibeMeter/Presentation/Components/StatusBarAccessibilityProvider.swift
@@ -54,25 +54,28 @@ final class StatusBarAccessibilityProvider {
         let totalSpendingUSD = spendingData.totalSpendingConverted(
             to: "USD",
             rates: currencyData.effectiveRates)
-        let upperLimit = settingsManager.upperLimitUSD
-        let percentage = (totalSpendingUSD / upperLimit * 100).rounded()
 
         let userSpending = spendingData.totalSpendingConverted(
             to: currencyData.selectedCode,
             rates: currencyData.effectiveRates)
-        let userLimit = settingsManager.upperLimitUSD * currencyData.effectiveRates[
-            currencyData.selectedCode,
-            default: 1.0
-        ]
-
         let spendingText =
             "\(currencyData.selectedSymbol)\(userSpending.formatted(.number.precision(.fractionLength(2))))"
-        let limitText = "\(currencyData.selectedSymbol)\(userLimit.formatted(.number.precision(.fractionLength(2))))"
 
-        let statusText = determineStatusText(for: percentage)
+        if settingsManager.limitsEnabled {
+            let upperLimit = settingsManager.upperLimitUSD
+            let percentage = (totalSpendingUSD / upperLimit * 100).rounded()
+            let userLimit = settingsManager.upperLimitUSD * currencyData.effectiveRates[
+                currencyData.selectedCode,
+                default: 1.0
+            ]
+            let limitText = "\(currencyData.selectedSymbol)\(userLimit.formatted(.number.precision(.fractionLength(2))))"
+            let statusText = determineStatusText(for: percentage)
 
-        return "\(statusText). Current spending: \(spendingText) of \(limitText) limit. " +
-            "\(Int(percentage)) percent used."
+            return "\(statusText). Current spending: \(spendingText) of \(limitText) limit. " +
+                "\(Int(percentage)) percent used."
+        } else {
+            return "Current spending: \(spendingText). Spending limits disabled."
+        }
     }
 
     private func determineStatusText(for percentage: Double) -> String {

--- a/VibeMeter/Presentation/Components/StatusBarController.swift
+++ b/VibeMeter/Presentation/Components/StatusBarController.swift
@@ -157,7 +157,7 @@ final class StatusBarController: NSObject {
                     to: "USD",
                     rates: currencyData.effectiveRates)
 
-                if totalSpendingUSD > 0 {
+                if totalSpendingUSD > 0 && settingsManager.limitsEnabled {
                     gaugeValue = min(max(totalSpendingUSD / settingsManager.upperLimitUSD, 0.0), 1.0)
                 } else {
                     gaugeValue = calculateRequestUsagePercentage()

--- a/VibeMeter/Presentation/Components/StatusBarTooltipProvider.swift
+++ b/VibeMeter/Presentation/Components/StatusBarTooltipProvider.swift
@@ -55,11 +55,17 @@ final class StatusBarTooltipProvider {
             to: "USD",
             rates: currencyData.effectiveRates)
 
-        if totalSpendingUSD > 0 {
+        if totalSpendingUSD > 0 && settingsManager.limitsEnabled {
             // Money has been spent - show spending as percentage of limit
             let upperLimit = settingsManager.upperLimitUSD
             let percentage = (totalSpendingUSD / upperLimit * 100).rounded()
             return "VibeMeter - \(Int(percentage))% of spending limit"
+        } else if !settingsManager.limitsEnabled && totalSpendingUSD > 0 {
+            // Limits disabled - just show spending amount
+            let userSpending = spendingData.totalSpendingConverted(
+                to: currencyData.selectedCode,
+                rates: currencyData.effectiveRates)
+            return "VibeMeter - \(currencyData.selectedSymbol)\(userSpending.formatted(.number.precision(.fractionLength(2))))"
         } else {
             // No money spent - show requests used as percentage of available limit
             let requestPercentage = calculateRequestUsagePercentage()

--- a/VibeMeter/Presentation/PreviewHelpers/MockSettingsManager.swift
+++ b/VibeMeter/Presentation/PreviewHelpers/MockSettingsManager.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public class MockSettingsManager: SettingsManagerProtocol {
     public var providerSessions: [ServiceProvider: ProviderSession] = [:]
     public var selectedCurrencyCode: String = "USD"
+    public var limitsEnabled: Bool = true
     public var warningLimitUSD: Double = 200
     public var upperLimitUSD: Double = 500
     public var refreshIntervalMinutes: Int = 5

--- a/VibeMeter/Presentation/Views/SpendingLimitsView.swift
+++ b/VibeMeter/Presentation/Views/SpendingLimitsView.swift
@@ -24,8 +24,11 @@ struct SpendingLimitsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                warningLimitSection
-                upperLimitSection
+                enableLimitsSection
+                if settingsManager?.limitsEnabled ?? true {
+                    warningLimitSection
+                    upperLimitSection
+                }
             }
             .formStyle(.grouped)
             .scrollContentBackground(.hidden)
@@ -54,7 +57,17 @@ struct SpendingLimitsView: View {
             .upperLimitUSD
     }
 
-    // MARK: - Helper Views
+    private var enableLimitsSection: some View {
+        Section {
+            Toggle("Enable Limits", isOn: Binding(
+                get: { settingsManager?.limitsEnabled ?? true },
+                set: { settingsManager?.limitsEnabled = $0 }
+            ))
+            Text("Disable limits for unlimited plans (e.g., Cursor Pro, Claude Max)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
 
     private var warningLimitSection: some View {
         Section {
@@ -179,9 +192,13 @@ struct SpendingLimitsView: View {
         HStack {
             Spacer()
             Text({
-                let limitText = "Limits are stored in USD and will be displayed in your selected currency " +
-                    "(\(currencyData.selectedCode)).\nSpending thresholds apply to Cursor."
-                return limitText
+                if settingsManager?.limitsEnabled ?? true {
+                    let limitText = "Limits are stored in USD and will be displayed in your selected currency " +
+                        "(\(currencyData.selectedCode)).\nSpending thresholds apply to Cursor."
+                    return limitText
+                } else {
+                    return "Spending limits are disabled. Perfect for unlimited subscription plans."
+                }
             }())
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/VibeMeterTests/SpendingLimitsToggleTests.swift
+++ b/VibeMeterTests/SpendingLimitsToggleTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import VibeMeter
+
+@Suite("Spending Limits Toggle Tests", .tags(.settings, .unit, .fast))
+@MainActor
+struct SpendingLimitsToggleTests {
+    let limitsManager: SpendingLimitsManager
+    let testUserDefaults: UserDefaults
+
+    init() {
+        // Unique suite name for UserDefaults to avoid interference between tests
+        let testSuiteName = "com.vibemeter.tests.SpendingLimitsToggleTests"
+        let suite = UserDefaults(suiteName: testSuiteName)!
+        suite.removePersistentDomain(forName: testSuiteName)
+        
+        self.testUserDefaults = suite
+        self.limitsManager = SpendingLimitsManager(userDefaults: testUserDefaults)
+    }
+
+    @Test("Limits enabled by default")
+    func limitsEnabledByDefault() {
+        #expect(limitsManager.limitsEnabled == true)
+    }
+
+    @Test("Can disable limits")
+    func canDisableLimits() {
+        limitsManager.limitsEnabled = false
+        #expect(limitsManager.limitsEnabled == false)
+        
+        // Verify persistence
+        let newManager = SpendingLimitsManager(userDefaults: testUserDefaults)
+        #expect(newManager.limitsEnabled == false)
+    }
+
+    @Test("Can re-enable limits")
+    func canReEnableLimits() {
+        limitsManager.limitsEnabled = false
+        limitsManager.limitsEnabled = true
+        
+        #expect(limitsManager.limitsEnabled == true)
+        
+        // Verify persistence
+        let newManager = SpendingLimitsManager(userDefaults: testUserDefaults)
+        #expect(newManager.limitsEnabled == true)
+    }
+
+    @Test("Reset to defaults enables limits")
+    func resetToDefaultsEnablesLimits() {
+        limitsManager.limitsEnabled = false
+        limitsManager.resetToDefaults()
+        
+        #expect(limitsManager.limitsEnabled == true)
+        #expect(limitsManager.warningLimitUSD == 200.0)
+        #expect(limitsManager.upperLimitUSD == 1000.0)
+    }
+} 

--- a/VibeMeterTests/TestUtilities/MockSettingsManager.swift
+++ b/VibeMeterTests/TestUtilities/MockSettingsManager.swift
@@ -9,6 +9,7 @@ import Foundation
 final class MockSettingsManager: SettingsManagerProtocol {
     var providerSessions: [ServiceProvider: ProviderSession] = [:]
     var selectedCurrencyCode: String = "USD"
+    var limitsEnabled: Bool = true
     var warningLimitUSD: Double = 200
     var upperLimitUSD: Double = 500
     var refreshIntervalMinutes: Int = 5
@@ -24,6 +25,7 @@ final class MockSettingsManager: SettingsManagerProtocol {
 
     init(
         selectedCurrencyCode: String = "USD",
+        limitsEnabled: Bool = true,
         warningLimitUSD: Double = 200,
         upperLimitUSD: Double = 500,
         refreshIntervalMinutes: Int = 5,
@@ -33,6 +35,7 @@ final class MockSettingsManager: SettingsManagerProtocol {
         enabledProviders: Set<ServiceProvider> = [.cursor],
         updateChannel: UpdateChannel = .stable) {
         self.selectedCurrencyCode = selectedCurrencyCode
+        self.limitsEnabled = limitsEnabled
         self.warningLimitUSD = warningLimitUSD
         self.upperLimitUSD = upperLimitUSD
         self.refreshIntervalMinutes = refreshIntervalMinutes
@@ -86,7 +89,7 @@ extension MockSettingsManager {
     }
 
     /// Creates a MockSettingsManager with custom limits
-    static func withLimits(warning: Double, upper: Double) -> MockSettingsManager {
-        MockSettingsManager(warningLimitUSD: warning, upperLimitUSD: upper)
+    static func withLimits(warning: Double, upper: Double, enabled: Bool = true) -> MockSettingsManager {
+        MockSettingsManager(limitsEnabled: enabled, warningLimitUSD: warning, upperLimitUSD: upper)
     }
 }


### PR DESCRIPTION
## What's Changed

This PR introduces a toggle to disable spending limits, suitable for users with unlimited subscription plans like Cursor Pro or Claude Max. 
Vibe coded with Opus.

### Features

- **New toggle in Spending Limits settings** - Flip the switch to disable limit warnings
- **Smart gauge behavior** - When limits are disabled, the gauge shows request usage percentage instead
- **Cleaner menu bar** - Spending limits section is hidden when disabled
- **No more notifications** - Warning and critical spending alerts are suppressed when limits are off
- **Better tooltips** - Shows actual spending amount instead of percentage when limits are disabled

### Implementation Details

- Added `limitsEnabled` property to `SpendingLimitsManager` with UserDefaults persistence
- Updated all relevant UI components to respect the toggle state
- Modified gauge calculations to fall back to request usage when limits are disabled
- Added comprehensive test coverage for the new functionality

### Screenshots

#### Settings View
<img width="587" alt="Screenshot 2025-06-20 at 12 13 51 AM" src="https://github.com/user-attachments/assets/7c3bbff4-d4fa-402a-a9fe-cbf43d53a33b" />

#### Menu Bar - Limits Enabled
<img width="344" alt="Screenshot 2025-06-20 at 12 14 02 AM" src="https://github.com/user-attachments/assets/70143763-9587-4548-a173-00349ec1e081" />

#### Menu Bar - Limits Disabled
<img width="361" alt="Screenshot 2025-06-20 at 12 14 20 AM" src="https://github.com/user-attachments/assets/41088104-fb52-40e0-99f6-e37bcda3ecb5" />

<img width="615" alt="Screenshot 2025-06-20 at 12 14 13 AM" src="https://github.com/user-attachments/assets/33ce7d81-68dc-4dcc-baf6-875d0efca822" />

### Testing

Run the new test suite:
```bash
swift test --filter SpendingLimitsToggleTests
```

### Notes

- The toggle defaults to enabled to maintain backward compatibility
- When limits are disabled, the footer text changes to reflect the unlimited plan context
- The reset to defaults action will re-enable limits

Fixes the need for users with unlimited plans to see spending limit warnings they don't care about. 